### PR TITLE
Provide initial bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,32 @@
+{
+  "name": "leaflet-layer-overpass",
+  "version": "1.0.0",
+  "homepage": "https://github.com/kartenkarsten/leaflet-layer-overpass",
+  "authors": [
+    "Karsten Hinz <k.hinz@tu-bs.de>",
+    "Knut Hühne <knut@k-nut.eu>"
+  ],
+  "description": "simply add an overpass layer to a leafleat map",
+  "main": "OverPassLayer.js",
+  "keywords": [
+    "leaflet",
+    "overpass",
+    "openstreetmap",
+    "osm",
+    "features",
+    "layer"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "demo",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": "~2.1.3",
+    "leaflet": "~0.7.3"
+  }
+}


### PR DESCRIPTION
All the fancy libraries use [bower](http://bower.io) nowadays. I added a `bower.json` file so that we can register the library as a bower package.
Then other people can simply use `bower install leaflet-layer-overpass` to get the latest version of the library directly installed to their dirctory.