### PR TITLE
Remove need for jQuery

### DIFF
--- a/OverPassLayer.js
+++ b/OverPassLayer.js
@@ -107,13 +107,12 @@ L.OverPassLayer = L.FeatureGroup.extend({
     endpoint: "http://overpass-api.de/api/",
     query: "(node(BBOX)[organic];node(BBOX)[second_hand];);out qt;",
     callback: function(map, data) {
-      for(i=0;i<data.elements.length;i++) {
+      for(var i = 0; i < data.elements.length; i++) {
         var e = data.elements[i];
 
         if (e.id in map._ids) return;
         map._ids[e.id] = true;
         var pos = new L.LatLng(e.lat, e.lon);
-        var popup = map._poiInfo(e.tags,e.id);
         var popup = map._poiInfo(e.tags,e.id);
         var circle = L.circle(pos, 50, {
           color: 'green',

--- a/OverPassLayer.js
+++ b/OverPassLayer.js
@@ -106,21 +106,21 @@ L.OverPassLayer = L.FeatureGroup.extend({
     minzoom: 15,
     endpoint: "http://overpass-api.de/api/",
     query: "(node(BBOX)[organic];node(BBOX)[second_hand];);out qt;",
-    callback: function(map, data) {
+    callback: function(data) {
       for(var i = 0; i < data.elements.length; i++) {
         var e = data.elements[i];
 
         if (e.id in map._ids) return;
-        map._ids[e.id] = true;
+        this._ids[e.id] = true;
         var pos = new L.LatLng(e.lat, e.lon);
-        var popup = map._poiInfo(e.tags,e.id);
+        var popup = this._poiInfo(e.tags,e.id);
         var circle = L.circle(pos, 50, {
           color: 'green',
           fillColor: '#3f0',
           fillOpacity: 0.5
         })
         .bindPopup(popup);
-        map.addLayer(circle);
+        this.addLayer(circle);
       }
     }
   },
@@ -235,7 +235,7 @@ L.OverPassLayer = L.FeatureGroup.extend({
 
           request.onload = function() {
             if (this.status >= 200 && this.status < 400) {
-              self.options.callback(self, JSON.parse(this.response));
+              self.options.callback.call(self, JSON.parse(this.response));
             } 
           };
 

--- a/OverPassLayer.js
+++ b/OverPassLayer.js
@@ -1,103 +1,103 @@
 L.Control.MinZoomIdenticator = L.Control.extend({
-	options: {
-		position: 'bottomleft',
-    },
+  options: {
+    position: 'bottomleft',
+  },
 
-    /**
-     * map: layerId -> zoomlevel
-     */
-    _layers: {},
+  /**
+  * map: layerId -> zoomlevel
+  */
+  _layers: {},
 
-    /** TODO check if nessesary
-     */
-	initialize: function (options) {
-		L.Util.setOptions(this, options);
-        this._layers = new Object();
-	},
+  /** TODO check if nessesary
+  */
+  initialize: function (options) {
+    L.Util.setOptions(this, options);
+    this._layers = new Object();
+  },
 
-    /**
-     * adds a layer with minzoom information to this._layers
-     */
-    _addLayer: function(layer) {
-        var minzoom = 15;
-        if (layer.options.minzoom) {
-            minzoom = layer.options.minzoom;
-        }
-        this._layers[layer._leaflet_id] = minzoom;
-        this._updateBox(null);
-    },
-    
-    /**
-     * removes a layer from this._layers
-     */
-    _removeLayer: function(layer) {
-        this._layers[layer._leaflet_id] = null;
-        this._updateBox(null);
-    },
+  /**
+  * adds a layer with minzoom information to this._layers
+  */
+  _addLayer: function(layer) {
+    var minzoom = 15;
+    if (layer.options.minzoom) {
+      minzoom = layer.options.minzoom;
+    }
+    this._layers[layer._leaflet_id] = minzoom;
+    this._updateBox(null);
+  },
 
-    _getMinZoomLevel: function() {
-        var minZoomlevel=-1;
-        for(var key in this._layers) {
-            if ((this._layers[key] != null)&&(this._layers[key] > minZoomlevel)) {
-                minZoomlevel = this._layers[key];
-            }
-        }
-        return minZoomlevel;
-    },
+  /**
+  * removes a layer from this._layers
+  */
+  _removeLayer: function(layer) {
+    this._layers[layer._leaflet_id] = null;
+    this._updateBox(null);
+  },
 
-    onAdd: function (map) {
-        this._map = map;
-        map.zoomIndecator = this;
+  _getMinZoomLevel: function() {
+    var minZoomlevel=-1;
+    for(var key in this._layers) {
+      if ((this._layers[key] != null)&&(this._layers[key] > minZoomlevel)) {
+        minZoomlevel = this._layers[key];
+      }
+    }
+    return minZoomlevel;
+  },
 
-        var className = this.className;
-        var container = this._container = L.DomUtil.create('div', className);
-        container.style.fontSize = "2em";
-        container.style.background = "#ffffff";
-        container.style.backgroundColor = "rgba(255,255,255,0.7)";
-        container.style.borderRadius = "10px";
-        container.style.padding = "1px 15px";
-        container.style.oppacity = "0.5";
-        map.on('moveend', this._updateBox, this);
-        this._updateBox(null);
+  onAdd: function (map) {
+    this._map = map;
+    map.zoomIndecator = this;
 
-        //        L.DomEvent.disableClickPropagation(container);
-        return container;
-    },
+    var className = this.className;
+    var container = this._container = L.DomUtil.create('div', className);
+    container.style.fontSize = "2em";
+    container.style.background = "#ffffff";
+    container.style.backgroundColor = "rgba(255,255,255,0.7)";
+    container.style.borderRadius = "10px";
+    container.style.padding = "1px 15px";
+    container.style.oppacity = "0.5";
+    map.on('moveend', this._updateBox, this);
+    this._updateBox(null);
 
-    onRemove: function(map) {
-        L.Control.prototype.onRemove.call(this, map);
-        map.off({
-            'moveend': this._updateBox
-        }, this);
+    //        L.DomEvent.disableClickPropagation(container);
+    return container;
+  },
 
-        this._map = null;
-    },
+  onRemove: function(map) {
+    L.Control.prototype.onRemove.call(this, map);
+    map.off({
+      'moveend': this._updateBox
+    }, this);
 
-    _updateBox: function (event) {
-        //console.log("map moved -> update Container...");
-		if (event != null) {
-            L.DomEvent.preventDefault(event);
-        }
-        var minzoomlevel = this._getMinZoomLevel();
-        if (minzoomlevel == -1) {
-            this._container.innerHTML = "no layer assigned";
-        }else{
-            this._container.innerHTML = "current Zoom-Level: "+this._map.getZoom()+" all data at Level: "+minzoomlevel;
-        }
+    this._map = null;
+  },
 
-        if (this._map.getZoom() >= minzoomlevel) {
-            this._container.style.display = 'none';
-        }else{
-            this._container.style.display = 'block';
-        }
-    },
+  _updateBox: function (event) {
+    //console.log("map moved -> update Container...");
+    if (event != null) {
+      L.DomEvent.preventDefault(event);
+    }
+    var minzoomlevel = this._getMinZoomLevel();
+    if (minzoomlevel == -1) {
+      this._container.innerHTML = "no layer assigned";
+    }else{
+      this._container.innerHTML = "current Zoom-Level: "+this._map.getZoom()+" all data at Level: "+minzoomlevel;
+    }
+
+    if (this._map.getZoom() >= minzoomlevel) {
+      this._container.style.display = 'none';
+    }else{
+      this._container.style.display = 'block';
+    }
+  },
 
   className : 'leaflet-control-minZoomIndecator'
 });
 
 L.LatLngBounds.prototype.toOverpassBBoxString = function (){
   var a = this._southWest,
-      b = this._northEast;
+  b = this._northEast;
   return [a.lat, a.lng, b.lat, b.lng].join(",");
 }
 
@@ -107,9 +107,9 @@ L.OverPassLayer = L.FeatureGroup.extend({
     endpoint: "http://overpass-api.de/api/",
     query: "(node(BBOX)[organic];node(BBOX)[second_hand];);out qt;",
     callback: function(data) {
-        if (this.instance._map == null) {
-            console.error("_map == null");
-        }
+      if (this.instance._map == null) {
+        console.error("_map == null");
+      }
       for(var i = 0, length = data.elements.length; i < length; i++) {
         var e = data.elements[i];
 
@@ -120,12 +120,12 @@ L.OverPassLayer = L.FeatureGroup.extend({
         var pos = new L.LatLng(e.lat, e.lon);
         var popup = this.instance._poiInfo(e.tags,e.id);
         var circle = L.circle(pos, 50, {
-            color: 'green',
-            fillColor: '#3f0',
-            fillOpacity: 0.5
+          color: 'green',
+          fillColor: '#3f0',
+          fillOpacity: 0.5
         })
-          .bindPopup(popup);
-          this.instance.addLayer(circle);
+        .bindPopup(popup);
+        this.instance.addLayer(circle);
       }
     }
   },
@@ -139,135 +139,148 @@ L.OverPassLayer = L.FeatureGroup.extend({
   },
 
   _poiInfo: function(tags,id) {
-    var link = '<a href="http://www.openstreetmap.org/edit?editor=id&node='+id+'">Edit this entry in iD</a><br>';
-    var r = $('<table>');
-    for (var key in tags)
-      r.append($('<tr>').append($('<th>').text(key)).append($('<td>').text(tags[key])));
-    return link + $('<div>').append(r).html();
+    var link = document.createElement("a");
+    link.href = "http://www.openstreetmap.org/edit?editor=id&node=" + id;
+    link.appendChild(document.createTextNode("Edit this entry in iD"));
+    var table = document.createElement('table');
+    for (var key in tags){
+      var row = table.insertRow(0);
+      row.insertCell(0).appendChild(document.createTextNode(key));
+      row.insertCell(1).appendChild(document.createTextNode(tags[key]));
+    }
+    var div = document.createElement("div")
+    div.appendChild(link);
+    div.appendChild(table);
+    return div;
   },
 
   /**
-   * splits the current view in uniform bboxes to allow caching
-   */
+  * splits the current view in uniform bboxes to allow caching
+  */
   long2tile: function (lon,zoom) { return (Math.floor((lon+180)/360*Math.pow(2,zoom))); },
   lat2tile: function (lat,zoom)  {
-      return (Math.floor((1-Math.log(Math.tan(lat*Math.PI/180) + 1/Math.cos(lat*Math.PI/180))/Math.PI)/2 *Math.pow(2,zoom))); 
+    return (Math.floor((1-Math.log(Math.tan(lat*Math.PI/180) + 1/Math.cos(lat*Math.PI/180))/Math.PI)/2 *Math.pow(2,zoom))); 
   },
   tile2long: function (x,z) {
-      return (x/Math.pow(2,z)*360-180);
+    return (x/Math.pow(2,z)*360-180);
   },
   tile2lat: function (y,z) {
-      var n=Math.PI-2*Math.PI*y/Math.pow(2,z);
-      return (180/Math.PI*Math.atan(0.5*(Math.exp(n)-Math.exp(-n))));
+    var n=Math.PI-2*Math.PI*y/Math.pow(2,z);
+    return (180/Math.PI*Math.atan(0.5*(Math.exp(n)-Math.exp(-n))));
   },
   _view2BBoxes: function(l,b,r,t) {
-      //console.log(l+"\t"+b+"\t"+r+"\t"+t);
-      //this.addBBox(l,b,r,t);
-      //console.log("calc bboxes");
-      var requestZoomLevel= 14;
-      //get left tile index
-      var lidx = this.long2tile(l,requestZoomLevel);
-      var ridx = this.long2tile(r,requestZoomLevel);
-      var tidx = this.lat2tile(t,requestZoomLevel);
-      var bidx = this.lat2tile(b,requestZoomLevel);
+    //console.log(l+"\t"+b+"\t"+r+"\t"+t);
+    //this.addBBox(l,b,r,t);
+    //console.log("calc bboxes");
+    var requestZoomLevel= 14;
+    //get left tile index
+    var lidx = this.long2tile(l,requestZoomLevel);
+    var ridx = this.long2tile(r,requestZoomLevel);
+    var tidx = this.lat2tile(t,requestZoomLevel);
+    var bidx = this.lat2tile(b,requestZoomLevel);
 
-      //var result;
-      var result = new Array();
-      for (var x=lidx; x<=ridx; x++) {
-          for (var y=tidx; y<=bidx; y++) {//in tiles tidx<=bidx
-              var left = Math.round(this.tile2long(x,requestZoomLevel)*1000000)/1000000;
-              var right = Math.round(this.tile2long(x+1,requestZoomLevel)*1000000)/1000000;
-              var top = Math.round(this.tile2lat(y,requestZoomLevel)*1000000)/1000000;
-              var bottom = Math.round(this.tile2lat(y+1,requestZoomLevel)*1000000)/1000000;
-              //console.log(left+"\t"+bottom+"\t"+right+"\t"+top);
-              //this.addBBox(left,bottom,right,top);
-              //console.log("http://osm.org?bbox="+left+","+bottom+","+right+","+top);
-              result.push( new L.LatLngBounds(new L.LatLng(bottom, left),new L.LatLng(top, right)));
-          }
+    //var result;
+    var result = new Array();
+    for (var x=lidx; x<=ridx; x++) {
+      for (var y=tidx; y<=bidx; y++) {//in tiles tidx<=bidx
+        var left = Math.round(this.tile2long(x,requestZoomLevel)*1000000)/1000000;
+        var right = Math.round(this.tile2long(x+1,requestZoomLevel)*1000000)/1000000;
+        var top = Math.round(this.tile2lat(y,requestZoomLevel)*1000000)/1000000;
+        var bottom = Math.round(this.tile2lat(y+1,requestZoomLevel)*1000000)/1000000;
+        //console.log(left+"\t"+bottom+"\t"+right+"\t"+top);
+        //this.addBBox(left,bottom,right,top);
+        //console.log("http://osm.org?bbox="+left+","+bottom+","+right+","+top);
+        result.push( new L.LatLngBounds(new L.LatLng(bottom, left),new L.LatLng(top, right)));
       }
-      //console.log(result);
-      return result;
+    }
+    //console.log(result);
+    return result;
   },
 
   addBBox: function (l,b,r,t) {
-      var polygon = L.polygon([
-              [t, l],
-              [b, l],
-              [b, r],
-              [t, r]
-              ]).addTo(this._map);
+    var polygon = L.polygon([
+      [t, l],
+      [b, l],
+      [b, r],
+      [t, r]
+    ]).addTo(this._map);
   },
 
   onMoveEnd: function () {
-      console.log("load Pois");
-      //console.log(this._map.getBounds());
-      if (this._map.getZoom() >= this.options.minzoom) {
-          //var bboxList = new Array(this._map.getBounds());
-          var bboxList = this._view2BBoxes(
-                  this._map.getBounds()._southWest.lng,
-                  this._map.getBounds()._southWest.lat,
-                  this._map.getBounds()._northEast.lng,
-                  this._map.getBounds()._northEast.lat);
+    console.log("load Pois");
+    //console.log(this._map.getBounds());
+    if (this._map.getZoom() >= this.options.minzoom) {
+      //var bboxList = new Array(this._map.getBounds());
+      var bboxList = this._view2BBoxes(
+        this._map.getBounds()._southWest.lng,
+        this._map.getBounds()._southWest.lat,
+        this._map.getBounds()._northEast.lng,
+        this._map.getBounds()._northEast.lat);
 
-          for (var i=0; i<bboxList.length; i++) {
-              var bbox = bboxList[i];
-              var x = bbox._southWest.lng;
-              var y = bbox._northEast.lat;
-              if ((x in this._requested) && (y in this._requested[x]) && (this._requested[x][y] == true)) {
-                  continue;
-              }
-              if (!(x in this._requested)) {
-                  this._requested[x] = {};
-              }
-              this._requested[x][y] = true;
-              //this.addBBox(x,bbox._southWest.lat,bbox._northEast.lng,y);
-
-              
-              var queryWithMapCoordinates = this.options.query.replace(/(BBOX)/g, bbox.toOverpassBBoxString());
-              var url =  this.options.endpoint + "interpreter?data=[out:json];" + queryWithMapCoordinates;
-
-              $.ajax({
-                  url: url,
-                  context: { instance: this },
-                  crossDomain: true,
-                  dataType: "json",
-                  data: {},
-                  success: this.options.callback
-              });
+        for (var i = 0; i < bboxList.length; i++) {
+          var bbox = bboxList[i];
+          var x = bbox._southWest.lng;
+          var y = bbox._northEast.lat;
+          if ((x in this._requested) && (y in this._requested[x]) && (this._requested[x][y] == true)) {
+            continue;
           }
-      }
+          if (!(x in this._requested)) {
+            this._requested[x] = {};
+          }
+          this._requested[x][y] = true;
+          //this.addBBox(x,bbox._southWest.lat,bbox._northEast.lng,y);
+
+
+          var queryWithMapCoordinates = this.options.query.replace(/(BBOX)/g, bbox.toOverpassBBoxString());
+          var url =  this.options.endpoint + "interpreter?data=[out:json];" + queryWithMapCoordinates;
+
+          var self = this;
+          var request = new XMLHttpRequest();
+          request.open("GET", url, true);
+
+          request.onload = function() {
+            if (this.status >= 200 && this.status < 400) {
+              self.options.callback(self, JSON.parse(this.response));
+            } 
+          };
+
+          request.send();
+
+
+        }
+    }
   },
 
   onAdd: function (map) {
-      this._map = map;
-      if (map.zoomIndecator) {
-          this._zoomControl = map.zoomIndecator;
-          this._zoomControl._addLayer(this);
-      }else{
-          this._zoomControl = new L.Control.MinZoomIdenticator();
-          map.addControl(this._zoomControl);
-          this._zoomControl._addLayer(this);
-      }
+    this._map = map;
+    if (map.zoomIndecator) {
+      this._zoomControl = map.zoomIndecator;
+      this._zoomControl._addLayer(this);
+    }else{
+      this._zoomControl = new L.Control.MinZoomIdenticator();
+      map.addControl(this._zoomControl);
+      this._zoomControl._addLayer(this);
+    }
 
-      this.onMoveEnd();
-      if (this.options.query.indexOf("(BBOX)") != -1) {
-          map.on('moveend', this.onMoveEnd, this);
-      }
-      console.log("add layer");
+    this.onMoveEnd();
+    if (this.options.query.indexOf("(BBOX)") != -1) {
+      map.on('moveend', this.onMoveEnd, this);
+    }
+    console.log("add layer");
   },
 
   onRemove: function (map) {
-      console.log("remove layer");
-      L.LayerGroup.prototype.onRemove.call(this, map);
-      this._ids = {};
-      this._requested = {};
-      this._zoomControl._removeLayer(this);
+    console.log("remove layer");
+    L.LayerGroup.prototype.onRemove.call(this, map);
+    this._ids = {};
+    this._requested = {};
+    this._zoomControl._removeLayer(this);
 
-      map.off({
-          'moveend': this.onMoveEnd
-      }, this);
+    map.off({
+      'moveend': this.onMoveEnd
+    }, this);
 
-      this._map = null;
+    this._map = null;
   },
 
   getData: function () {

--- a/OverPassLayer.js
+++ b/OverPassLayer.js
@@ -110,17 +110,17 @@ L.OverPassLayer = L.FeatureGroup.extend({
       for(var i = 0; i < data.elements.length; i++) {
         var e = data.elements[i];
 
-        if (e.id in map._ids) return;
-        this._ids[e.id] = true;
+        if (e.id in this.instance._ids) return;
+        this.instance._ids[e.id] = true;
         var pos = new L.LatLng(e.lat, e.lon);
-        var popup = this._poiInfo(e.tags,e.id);
+        var popup = this.instance._poiInfo(e.tags,e.id);
         var circle = L.circle(pos, 50, {
           color: 'green',
           fillColor: '#3f0',
           fillOpacity: 0.5
         })
         .bindPopup(popup);
-        this.addLayer(circle);
+        this.instance.addLayer(circle);
       }
     }
   },
@@ -235,7 +235,8 @@ L.OverPassLayer = L.FeatureGroup.extend({
 
           request.onload = function() {
             if (this.status >= 200 && this.status < 400) {
-              self.options.callback.call(self, JSON.parse(this.response));
+              var reference = {instance: self};
+              self.options.callback.call(reference, JSON.parse(this.response));
             } 
           };
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ options: {
   endpoint: "http://overpass.osm.rambler.ru/cgi/",
   query: "node(BBOX)[amenity=post_box];out;",
   callback: function(data) {
-    for(i=0;i<data.elements.length;i++) {
+    for(var i=0;i<data.elements.length;i++) {
       var e = data.elements[i];
 
       if (e.id in this.instance._ids) return;
@@ -44,7 +44,7 @@ options: {
         fillOpacity: 0.5
       })
       .bindPopup(popup);
-      map.addLayer(circle);
+      this.instance.addLayer(circle);
     }
   },
 };

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var map = new L.Map('map').addLayer(osm).setView(new L.LatLng(52.265, 10.524), 1
 
 //OverPassAPI overlay
 var opl = new L.OverPassLayer({
-  query: "http://overpass-api.de/api/interpreter?data=[out:json];node(BBOX)[amenity=post_box];out;",
+  query: "node(BBOX)[amenity=post_box];out;",
 }
 
 map.addLayer(opl);
@@ -27,7 +27,8 @@ In order to get an valid query the [Overpass-turbo IDE](http://overpass-turbo.eu
 You can specify an options object as an argument of L.OverPassLayer.
 ```javascript
 options: {
-  query: "http://overpass-api.de/api/interpreter?data=[out:json];node(BBOX)[amenity=post_box];out;",
+  endpoint: "http://overpass.osm.rambler.ru/cgi/",
+  query: "node(BBOX)[amenity=post_box];out;",
   callback: function(data) {
     for(i=0;i<data.elements.length;i++) {
       e = data.elements[i];
@@ -55,7 +56,7 @@ options: {
 
 ## Dependencies
 - JQuery (version 1.8.0 is working). JQuery does the AJAX requests and creats the popup content. (Might be replaceable by [Leaflet-Ajax](https://github.com/calvinmetcalf/leaflet-ajax))
-- Leaflet (tried with version 0.6.2)
+- Leaflet (tried with version 0.6.2, 0.7.3)
 
 
 ## Further Ideas

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,6 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "~2.1.3",
     "leaflet": "~0.7.3"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,32 @@
+{
+  "name": "leaflet-layer-overpass",
+  "version": "1.0.0",
+  "homepage": "https://github.com/kartenkarsten/leaflet-layer-overpass",
+  "authors": [
+    "Karsten Hinz <k.hinz@tu-bs.de>",
+    "Knut Hühne <knut@k-nut.eu>"
+  ],
+  "description": "simply add an overpass layer to a leafleat map",
+  "main": "OverPassLayer.js",
+  "keywords": [
+    "leaflet",
+    "overpass",
+    "openstreetmap",
+    "osm",
+    "features",
+    "layer"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "demo",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": "~2.1.3",
+    "leaflet": "~0.7.3"
+  }
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -35,10 +35,10 @@
         for(var i=0;i<data.elements.length;i++) {
           var e = data.elements[i];
 
-          if (e.id in this._ids) return;
-          this._ids[e.id] = true;
+          if (e.id in this.instance._ids) return;
+          this.instance._ids[e.id] = true;
           var pos = new L.LatLng(e.lat, e.lon);
-          var popup = this._poiInfo(e.tags,e.id);
+          var popup = this.instance._poiInfo(e.tags,e.id);
           var color = e.tags.collection_times ? 'green':'red';
           var circle = L.circle(pos, 50, {
             color: color,
@@ -46,7 +46,7 @@
             fillOpacity: 0.5
           })
           .bindPopup(popup);
-          this.addLayer(circle);
+          this.instance.addLayer(circle);
         }
       },
     });

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,6 @@
   <title>OverPass Layer Demo</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script src="http://code.jquery.com/jquery-1.8.0.min.js"></script>
   <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.2/leaflet.css" />
   <script src="http://cdn.leafletjs.com/leaflet-0.6.2/leaflet-src.js"></script>
   <script src="../OverPassLayer.js"></script>
@@ -32,14 +31,14 @@
     var opl = new L.OverPassLayer({
       endpoint: "http://overpass.osm.rambler.ru/cgi/",
       query: "node(BBOX)[amenity=post_box];out;",
-      callback: function(data) {
+      callback: function(map, data) {
         for(i=0;i<data.elements.length;i++) {
-          e = data.elements[i];
+          var e = data.elements[i];
 
-          if (e.id in this.instance._ids) return;
-          this.instance._ids[e.id] = true;
+          if (e.id in map._ids) return;
+          map._ids[e.id] = true;
           var pos = new L.LatLng(e.lat, e.lon);
-          var popup = this.instance._poiInfo(e.tags,e.id);
+          var popup = map._poiInfo(e.tags,e.id);
           var color = e.tags.collection_times ? 'green':'red';
           var circle = L.circle(pos, 50, {
             color: color,
@@ -47,7 +46,7 @@
             fillOpacity: 0.5
           })
           .bindPopup(popup);
-          this.instance.addLayer(circle);
+          map.addLayer(circle);
         }
       },
     });

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,14 +31,14 @@
     var opl = new L.OverPassLayer({
       endpoint: "http://overpass.osm.rambler.ru/cgi/",
       query: "node(BBOX)[amenity=post_box];out;",
-      callback: function(map, data) {
-        for(i=0;i<data.elements.length;i++) {
+      callback: function(data) {
+        for(var i=0;i<data.elements.length;i++) {
           var e = data.elements[i];
 
-          if (e.id in map._ids) return;
-          map._ids[e.id] = true;
+          if (e.id in this._ids) return;
+          this._ids[e.id] = true;
           var pos = new L.LatLng(e.lat, e.lon);
-          var popup = map._poiInfo(e.tags,e.id);
+          var popup = this._poiInfo(e.tags,e.id);
           var color = e.tags.collection_times ? 'green':'red';
           var circle = L.circle(pos, 50, {
             color: color,
@@ -46,7 +46,7 @@
             fillOpacity: 0.5
           })
           .bindPopup(popup);
-          map.addLayer(circle);
+          this.addLayer(circle);
         }
       },
     });


### PR DESCRIPTION
This PR removes the need to include jquery. The style of the popups is a little different now. One could of course use the original style though... Maybe I am going to add this to this PR in a later commit.  The unfortunate thing is that I also had to change the callback signature.
jQuery allowed us to pass a reference to `this` to the callback function. I did not figure out how to do this without jQuery. Would you know how to do this? 
I also by mistake reformated all the lines which makes the patch quite messy. You should probably look at the [`--ignore-all-whitespace` version](https://github.com/k-nut/leaflet-layer-overpass/commit/30687c44be4cc9f3499f3c625559c77ba005d302?w=1) to see what really changed.